### PR TITLE
新規インストール時に%APPDATA%\RelaxTools-Addinを作成する

### DIFF
--- a/install.vbs
+++ b/install.vbs
@@ -46,6 +46,11 @@ End IF
 'ファイルコピー(上書き) 
 objFileSys.CopyFile  addInFileName ,installPath , True
 
+'イメージフォルダがない場合は作成
+IF Not objFileSys.FolderExists(imageFolder) THEN
+  objFileSys.CreateFolder(imageFolder)
+END IF
+
 'イメージフォルダをコピー(上書き) 
 objFileSys.CopyFolder  "Source\customUI\images" ,imageFolder , True
 


### PR DESCRIPTION
## エラー内容
* OS: Windows 7
* install.vbs の`objFileSys.CopyFolder  "Source\customUI\images" ,imageFolder , True`
で%APPDATA%\RelaxTools-Addin 以下にimages フォルダをコピーしますが、その際に%APPDATA%\RelaxTools-Addin がないとエラーとなります。  

参考  
https://msdn.microsoft.com/ja-jp/library/cc427986.aspx  
> 引数 source にワイルドカード文字を使用したとき、および引数 destination がパスの区切り文字 (\) で終わるときは、引数 destination には既存フォルダを指定したと判断され、条件に一致するフォルダおよびサブフォルダがそのフォルダ内へコピーされます。

## 修正内容
%APPDATA%\RelaxTools-Addin が存在しない場合作成する処理を追加しました。