### PR TITLE
Markdown変換でセル内改行を<br>に変換するようにした

### DIFF
--- a/Source/src/Form/frmMarkdown.frm
+++ b/Source/src/Form/frmMarkdown.frm
@@ -178,6 +178,7 @@ Function CharacterStyle(ByRef r As Range) As String
     Dim strTag As String
     Dim blnStart As Boolean
     Dim blnEnd As Boolean
+    Dim strTmp As String
     
     For i = 1 To r.Characters.Count
     
@@ -221,7 +222,8 @@ Function CharacterStyle(ByRef r As Range) As String
             Case blnEnd
                 strBuf = strBuf & strTag & r.Characters(i, 1).Text
             Case Else
-                strBuf = strBuf & r.Characters(i, 1).Text
+                strTmp = r.Characters(i, 1).Text
+                strBuf = strBuf & IIf(strTmp = vbLf, "<br>", strTmp)
         End Select
     
     Next


### PR DESCRIPTION
セル内改行があると、Markdown変換で表が崩れて変換されてしまいます。
改行(vbLf)を、`<br>`に変換するようにしました。

### 変更前
```
|テキスト|やさい|
|---|---|
|普
通|ナス|
|**太字
のみ**|トマト|
|__斜体
のみ__|ズッキーニ|
```
### 変更後
```
|テキスト|やさい|
|---|---|
|普<br>通|ナス|
|**太字<br>のみ**|トマト|
|__斜体<br>のみ__|ズッキーニ|
````

Github,Qiitaでは正しく改行が表示されていました。
Backlogは未確認です。

_xlamはdiffが見れないので含んでいません。_
