### PR TITLE
「アクティブなブックの名前を変更」にてファイル名の最初のピリオド以下を拡張子として扱う問題の修正

### DIFF
--- a/Source/src/Modules/basCommon.bas
+++ b/Source/src/Modules/basCommon.bas
@@ -2494,7 +2494,7 @@ Sub RenameActiveBook()
     End If
     
     strName = rlxGetFullpathFromExt(strFile)
-    strExt = Mid(strFile, InStr(strFile, "."))
+    strExt = Mid(strFile, InStrRev(strFile, "."))
     
     strBuf = InputBox("変更後のブック名を入力してください。", "アクティブなブックの名前を変更", strName)
     If Trim(strBuf) = "" Then


### PR DESCRIPTION
### 概要

「アクティブなブックの名前を変更」にてファイル名に含まれる最初のピリオド以下を拡張子として取得しているため、変更後のファイル名に変更前のファイル名が含まれてしまう。

#### 例

元のファイル名：01.Book1.xlsx
変更したいファイル名：02.Book2.xlsx
実際に変更されたファイル名：02.Book2.Book1.xlsx

### 原因

ファイル名部分を取得する場合のピリオドの位置と、
拡張子部分を取得する場合のピリオドの位置がずれているため。

#### 例

変更前のファイル名として取得される部分：「01.Book1」
変更前の拡張子として取得される部分：「Book1.xlsx」
変更後のファイル名として入力した文字列：「02.Book2」
実際に変更されたファイル名：「02.Book2」＋ "." ＋「Book1.xlsx」

### 修正案

```vba
#最初のピリオド以下を拡張子とする
strExt = Mid(strFile, InStr(strFile, "."))
#最後のピリオド以下を拡張子とする
strExt = Mid(strFile, InStrRev(strFile, "."))
```