### PR TITLE
A1セットの際に複数セルの選択が解除されない問題 #65 の修正

### DIFF
--- a/Source/src/Modules/basMacro.bas
+++ b/Source/src/Modules/basMacro.bas
@@ -497,7 +497,7 @@ Sub setAllA1()
     For Each WS In WB.Worksheets
         If WS.visible = xlSheetVisible Then
             WS.Activate
-            WS.Range("A1").Activate
+            WS.Range("A1").Select
             WB.Windows(1).ScrollRow = 1
             WB.Windows(1).ScrollColumn = 1
             


### PR DESCRIPTION
Closes #65  
A1を含む複数セルを範囲選択している状態で、「カーソルをホームポジション（A1）にセット」の機能を使用すると、範囲選択が解除されずに範囲内のA1を選択した状態になります。
範囲選択が解除されA1のみ選択している状態が想定された挙動かと思われます。

Activateでは範囲選択中の中でアクティブなセルを選択する動作となるため、Selectによる単一セルの選択に変更しました。